### PR TITLE
[Fix]: 一覧画面の瓶詰め表記を修正

### DIFF
--- a/src/components/parts/listItem.tsx
+++ b/src/components/parts/listItem.tsx
@@ -42,9 +42,7 @@ export const ListItem = (props: ListItemProps) => {
               <span className="block font-medium">蒸溜: {data.vintage}年</span>
             )}
             {data.bottled && data.bottled > 0 && (
-              <span className="block font-medium">
-                瓶詰め: {data.bottled}年
-              </span>
+              <span className="block font-medium">瓶詰: {data.bottled}年</span>
             )}
             <Rating rating={data.rating ? data.rating : 0} readOnly withLabel />
           </div>


### PR DESCRIPTION
一覧画面の瓶詰め表記を、  
「瓶詰め」から「瓶詰」に変更